### PR TITLE
Fix defaults and inputs merging bug in mock-observations

### DIFF
--- a/src/lib/mock-observations/index.ts
+++ b/src/lib/mock-observations/index.ts
@@ -40,7 +40,7 @@ export const MockObservations = (
             generatorToHistory
           );
 
-          acc.push(Object.assign(observation, defaults));
+          acc.push(Object.assign({}, defaults, observation));
         });
 
         return acc;


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
- Fix the case where, in the manifest with mock-observations parameters, `inputs` have data, and all `outputs` have the same `timestamp` as those in the inputs.
- you can test this fix in the watt-time.yml 


<!-- Make sure tests and lint pass on CI. -->

