### PR TITLE
remove cpu/utilization for clarity

### DIFF
--- a/src/lib/cloud-metadata/README.md
+++ b/src/lib/cloud-metadata/README.md
@@ -88,7 +88,6 @@ tree:
           cloud/vendor: aws
           cloud/instance-type: m5n.large
           duration: 100
-          cpu/utilization: 10
 ```
 
 Ensure that you have global node_modules bin directory in your $PATH
@@ -136,7 +135,6 @@ tree:
           cloud/vendor: aws
           cloud/instance-type: m5n.large
           duration: 100
-          cpu/utilization: 10
           vcpus-allocated: 2
           vcpus-total: 96
           memory-available: 8


### PR DESCRIPTION
the `cpu/utilization: 10` in the manifest is not needed to run this particular plugin - including it causes no errors, but removing it from the readme might clarify what exactly is needed for this specific plugin and what is rendered in the output field as a result, vs. extraneous.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
<!--- Provide a small description of the changes. -->
- 
- 


<!-- Make sure tests and lint pass on CI. -->

