### PR TITLE
Rename csv-export plugin to grafana-export plugin

### DIFF
--- a/src/__tests__/unit/lib/grafana-export/index.test.ts
+++ b/src/__tests__/unit/lib/grafana-export/index.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs/promises';
 import {jest} from '@jest/globals';
 
-import {CsvExport} from '../../../../lib/csv-export';
+import {GrafanaExport} from '../../../../lib/grafana-export';
 
 import {ERRORS} from '../../../../util/errors';
 
@@ -12,7 +12,7 @@ jest.mock('fs/promises', () => ({
   writeFile: jest.fn<() => Promise<void>>().mockResolvedValue(),
 }));
 
-describe('lib/csv-export: ', () => {
+describe('lib/grafana-export: ', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -28,7 +28,7 @@ describe('lib/csv-export: ', () => {
         'output-path': path,
         headers: ['timestamp', 'duration'],
       };
-      const csvExport = CsvExport();
+      const grafanaExport = GrafanaExport();
 
       const input = [
         {
@@ -45,7 +45,7 @@ describe('lib/csv-export: ', () => {
         },
       ];
 
-      const result = await csvExport.execute(input, basicConfig);
+      const result = await grafanaExport.execute(input, basicConfig);
 
       expect.assertions(3);
 
@@ -63,7 +63,7 @@ describe('lib/csv-export: ', () => {
         'output-path': path,
         headers: ['timestamp', 'duration', 'water'],
       };
-      const csvExport = CsvExport();
+      const grafanaExport = GrafanaExport();
 
       const input = [
         {
@@ -82,7 +82,7 @@ describe('lib/csv-export: ', () => {
         },
       ];
 
-      const result = await csvExport.execute(input, basicConfig);
+      const result = await grafanaExport.execute(input, basicConfig);
 
       expect.assertions(3);
 
@@ -96,7 +96,7 @@ describe('lib/csv-export: ', () => {
     });
 
     it('executes with empty headers and will write all input data to csv.', async () => {
-      const csvExport = CsvExport();
+      const grafanaExport = GrafanaExport();
 
       const input = [
         {
@@ -113,7 +113,7 @@ describe('lib/csv-export: ', () => {
         },
       ];
 
-      const result = await csvExport.execute(input, standardConfig);
+      const result = await grafanaExport.execute(input, standardConfig);
 
       expect.assertions(3);
 
@@ -127,7 +127,7 @@ describe('lib/csv-export: ', () => {
     });
 
     it('throws an error when node config is not provided.', async () => {
-      const csvExport = CsvExport();
+      const grafanaExport = GrafanaExport();
 
       const input = [
         {
@@ -147,11 +147,13 @@ describe('lib/csv-export: ', () => {
       expect.assertions(2);
 
       try {
-        await csvExport.execute(input);
+        await grafanaExport.execute(input);
       } catch (error) {
         expect(error).toBeInstanceOf(InputValidationError);
         expect(error).toEqual(
-          new InputValidationError('CsvExport: Configuration data is missing.')
+          new InputValidationError(
+            'GrafanaExport: Configuration data is missing.'
+          )
         );
       }
     });
@@ -160,7 +162,7 @@ describe('lib/csv-export: ', () => {
       (fs.writeFile as jest.Mock).mockImplementation(() => {
         throw new Error('Permission denied');
       });
-      const csvExport = CsvExport();
+      const grafanaExport = GrafanaExport();
 
       const input = [
         {
@@ -172,12 +174,12 @@ describe('lib/csv-export: ', () => {
       expect.assertions(2);
 
       try {
-        await csvExport.execute(input, standardConfig);
+        await grafanaExport.execute(input, standardConfig);
       } catch (error) {
         expect(error).toBeInstanceOf(WriteFileError);
         expect(error).toEqual(
           new WriteFileError(
-            `CsvExport: Failed to write CSV to ${path} Error: Permission denied.`
+            `GrafanaExport: Failed to write CSV to ${path} Error: Permission denied.`
           )
         );
       }
@@ -188,7 +190,7 @@ describe('lib/csv-export: ', () => {
         throw new Error('Permission denied');
       });
 
-      const csvExport = CsvExport();
+      const grafanaExport = GrafanaExport();
       const input = [
         {
           timestamp: '2023-12-12T00:00:00.000Z',
@@ -199,12 +201,12 @@ describe('lib/csv-export: ', () => {
       expect.assertions(2);
 
       try {
-        await csvExport.execute(input, standardConfig);
+        await grafanaExport.execute(input, standardConfig);
       } catch (error) {
         expect(error).toBeInstanceOf(MakeDirectoryError);
         expect(error).toEqual(
           new MakeDirectoryError(
-            'CsvExport: Failed to create directory for CSV at path: . Error: Permission denied.'
+            'GrafanaExport: Failed to create directory for CSV at path: . Error: Permission denied.'
           )
         );
       }

--- a/src/lib/grafana-export/README.md
+++ b/src/lib/grafana-export/README.md
@@ -1,4 +1,6 @@
-# CSV Export
+# Grafana Exporter
+
+Grafana exporter is a modified csv exporter that outputs csv data in a format that works well with our Grafana dashboard.
 
 # Parameters
 
@@ -10,8 +12,7 @@ Required fields:
 
 Optional fields:
 
-- `headers`: A list of headers to extract from the inputs to write as columns in the csv file. An empty list of headers will write all fields provided as inputs to the pluginParams.
-  The default list of headers is empty therefore all input data will be written to the csv file.
+- `headers`: A list of headers to extract from the inputs to write as columns in the csv file. An empty list of headers will write all fields provided as inputs to the `pluginParams`. The default list of headers is empty therefore all input data will be written to the csv file.
 
 ## Inputs
 
@@ -26,8 +27,8 @@ This plugin will write externally to disk as csv file and pass the inputs direct
 To run the plugin, you must first create an instance of `CsvExport` and call its `execute()` function with the desired inputs
 
 ```typescript
-import {CsvExport} from '@grnsft/if-plugins';
-const output = CsvExport();
+import {GrafanaExport} from '@grnsft/if-plugins';
+const output = GrafanaExport();
 const result = await output.execute([
   {
     timestamp: '2023-07-06T00:00',
@@ -45,27 +46,28 @@ const result = await output.execute([
 IF users will typically call the plugin as part of a pipeline defined in a `manifest`
 file. In this case, instantiating the plugin is handled by
 `ie` and does not have to be done explicitly by the user.
-The following is an example `manifest` that calls `csv-export.yml`:
+
+The following is an example `manifest` that runs `grafana-export.yml`:
 
 ```yaml
-name: csv-export-demo
+name: grafana-export-demo
 description: example exporting output to a csv file
 tags:
 initialize:
   outputs:
     - yaml
   plugins:
-    csv-exporter:
-      method: CsvExport
+    grafana-exporter:
+      method: GrafanaExport
       path: '@grnsft/if-plugins'
 tree:
   children:
     child:
       pipeline:
-        - csv-exporter
+        - grafana-exporter
       config:
-        csv-exporter:
-          output-path: C:/dev/csv-export.csv
+        grafana-exporter:
+          output-path: C:/dev/grafana-export.csv
           headers:
             - timestamp
             - duration
@@ -86,12 +88,12 @@ tree:
           carbon: 4.03
 ```
 
-You can run this example `manifest` by saving it as `./examples/manifests/test/csv-export.yml` and executing the following command from the project root:
+You can run this example `manifest` by saving it as `./examples/manifests/test/grafana-export.yml` and executing the following command from the project root:
 
 ```sh
 npm i -g @grnsft/if
 npm i -g @grnsft/if-plugins
-ie --manifest ./examples/manifests/test/csv-export.yml.yml --output ./examples/outputs/csv-export.yml.yml
+ie --manifest ./examples/manifests/test/grafana-export.yml --output ./examples/outputs/grafana-export
 ```
 
 The results will be saved into the `output-path`.

--- a/src/lib/grafana-export/index.ts
+++ b/src/lib/grafana-export/index.ts
@@ -11,10 +11,10 @@ import {ERRORS} from '../../util/errors';
 
 const {MakeDirectoryError, WriteFileError, InputValidationError} = ERRORS;
 
-export const CsvExport = (): PluginInterface => {
+export const GrafanaExport = (): PluginInterface => {
   const metadata = {kind: 'execute'};
 
-  const errorBuilder = buildErrorMessage(CsvExport.name);
+  const errorBuilder = buildErrorMessage(GrafanaExport.name);
 
   const createCsvContent = (
     inputs: PluginParams[],

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,7 +8,7 @@ export {SciO} from './sci-o';
 export {Shell} from './shell';
 export {TdpFinder} from './tdp-finder';
 export {MockObservations} from './mock-observations';
-export {CsvExport} from './csv-export';
+export {GrafanaExport} from './grafana-export';
 export {Multiply} from './multiply';
 export {Sum} from './sum';
 export {Coefficient} from './coefficient';


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Enhancement (project structure, spelling, grammar, formatting)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
This PR clears up the confusion between our builtin csv exporter and the scv exporter plugin. The plugin is designed to output data specifically to support our grafana dashboard, so it is here renamed `grafana-exporter`. This should help users to distinguish between the two features and make the separation of config in manifests easier.

<!-- Make sure tests and lint pass on CI. -->

